### PR TITLE
Fixing #21: jasmine should be in devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,14 +17,16 @@
 	"ignore": [
 		"node_modules",
 		"bower_components",
-		"test"
+		"test",
+		"examples",
+		"Gruntfile.js"
 	],
 	"dependencies": {
-		"angular": ">= 1.1.7",
-        "jasmine": ">= 1.3.1"
-    },
-    "devDependencies": {
-	    "angular-mocks": ">= 1.1.7",
-        "jasmine-jquery": "~1.3.1"
-    }
+		"angular": ">= 1.1.7"
+    	},
+	"devDependencies": {
+		"angular-mocks": ">= 1.1.7",
+		"jasmine": ">= 1.3.1",
+		"jasmine-jquery": "~1.3.1"
+	}
 }


### PR DESCRIPTION
Also, `examples` and `Gruntfile.js` should be ignored by bower.