### PR TITLE
set trunction state to false when it is not truncated

### DIFF
--- a/src/angular-ellipsis.js
+++ b/src/angular-ellipsis.js
@@ -152,6 +152,9 @@ angular.module('dibari.angular-ellipsis', [])
 								$sce.trustAsHtml(binding);
 							}
 						}
+						else{
+							element.attr('data-overflowed', 'false');
+						}
 					}
 				}
 


### PR DESCRIPTION
set the state attribute "data-overflowed" to false if the text is not truncated.
it is useful when the text can change dynamically and other parts of the application need to know whether the text is truncated. 