### PR TITLE
Listen for an event to allow refreshing the ellipsis

### DIFF
--- a/src/angular-ellipsis.js
+++ b/src/angular-ellipsis.js
@@ -212,6 +212,9 @@ angular.module('dibari.angular-ellipsis', [])
 					attributes.lastWindowResizeHeight = window.innerHeight;
 				}
 
+				var unbindRefreshEllipsis = scope.$on('dibari:refresh-ellipsis', function() {
+					asyncDigestImmediate.add(buildEllipsis);
+				});
 				/**
 				 *	When window width or height changes - re-init truncation
 				 */
@@ -230,6 +233,10 @@ angular.module('dibari.angular-ellipsis', [])
 					$win.unbind('resize', onResize);
 					asyncDigestImmediate.remove(buildEllipsis);
 					asyncDigestDebounced.remove(checkWindowForRebuild);
+					if (unbindRefreshEllipsis) {
+						unbindRefreshEllipsis();
+						unbindRefreshEllipsis = null;
+					}
 				});
 
 


### PR DESCRIPTION
Hello,

I added an event that allows users of the directive to tell it if it needs to rebuild. This makes it easy to implement collapse/expand functionality by just toggling a class and triggering the event: `$scope.$broadcast('dibari:refresh-ellipsis');`. Maybe this also solves issue #2?

Best,
Georgi
