### PR TITLE
Implement ellipsis support for elements which are shown/hidden ...

### DIFF
--- a/src/angular-ellipsis.js
+++ b/src/angular-ellipsis.js
@@ -54,6 +54,7 @@ angular.module('dibari.angular-ellipsis', [])
 	return {
 		restrict: 'A',
 		scope: {
+			ngShow: '=',
 			ngBind: '=',
 			ngBindHtml: '=',
 			ellipsisAppend: '@',
@@ -174,6 +175,13 @@ angular.module('dibari.angular-ellipsis', [])
 				/**
 				 *	Watchers
 				 */
+
+				/**
+				 *	Execute ellipsis truncate on ngBind update
+				 */
+				scope.$watch('ngShow', function() {
+					asyncDigestImmediate.add(buildEllipsis);
+				});
 
 				/**
 				 *	Execute ellipsis truncate on ngBind update

--- a/src/angular-ellipsis.js
+++ b/src/angular-ellipsis.js
@@ -177,7 +177,7 @@ angular.module('dibari.angular-ellipsis', [])
 				 */
 
 				/**
-				 *	Execute ellipsis truncate on ngBind update
+				 *	Execute ellipsis truncate on ngShow update
 				 */
 				scope.$watch('ngShow', function() {
 					asyncDigestImmediate.add(buildEllipsis);


### PR DESCRIPTION
Ellipsis won't work for initially hidden elements with ng-show. Fixed this by simply adding a listener on ngShow. I figured out this would be a good fix also for the base.