### PR TITLE
remove implicit dependency on jQuery

### DIFF
--- a/src/angular-ellipsis.js
+++ b/src/angular-ellipsis.js
@@ -153,7 +153,8 @@ angular.module('dibari.angular-ellipsis', [])
 
 							// If append string was passed and append click function included
 							if (ellipsisSymbol != appendString && typeof(scope.ellipsisAppendClick) !== 'undefined' && scope.ellipsisAppendClick !== '') {
-								element.find('span.angular-ellipsis-append').bind("click", function(e) {
+								var clickArea = angular.element(element[0].querySelector('span.angular-ellipsis-append'));
+                                				clickArea.bind("click", function(e) {
 									scope.$apply(function() {
 										scope.ellipsisAppendClick.call(scope, {
 											event: e


### PR DESCRIPTION
built in angular.find only works support element name for selectors. As such there is an implicit dependency on jQuery by using element.find.